### PR TITLE
Add minimal MCP server and enhance README with tech stack guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,18 @@ Follow the instructions in the MD file you can curl from https://radar.sandbox.a
 @Cursor repo=aetheronhq/YOUR_REPO_NAME Follow the instructions in the MD file you can curl from https://radar.sandbox.aetheron.com/action-setup.md
 ```
 
+**You can also install the Radar MCP server in Cursor / Claude Code**
+```json
+{
+  "mcpServers": {
+    "aetheron-radar": {
+      "command": "uv",
+      "args": ["run", "https://radar.sandbox.aetheron.com/radar-mcp.py"]
+    }
+  }
+}
+```
+
 ## Why this exists
 - **Internal**: clear defaults, faster decisions, easier onboarding, a place to propose/track experiments, and shared "when to use X vs Y" guidance.
 - **External**: signals we're modern and intentional, shows quality to candidates/clients, and serves as a strong tech‑marketing asset.
@@ -133,6 +145,32 @@ See [ACTION_SETUP.md](public/action-setup.md) for detailed instructions on:
 
 # Deploy to S3 (requires AWS credentials)
 ./deploy.sh
+```
+
+### MCP tool for programmatic access
+
+We also publish a minimal MCP server exposing one `get_tech_stack_guidance` tool that returns entries from the hosted JSON with optional filters.
+The MCP server gives you access to the radar data at the AI agent level, avoiding per-repo setup.
+
+Client config example (Cursor/Claude-like):
+```json
+{
+  "mcpServers": {
+    "aetheron-radar": {
+      "command": "uv",
+      "args": ["run", "https://radar.sandbox.aetheron.com/radar-mcp.py"]
+    }
+  }
+}
+```
+
+Tool: `get_tech_stack_guidance(quadrant?: int | int[], ring?: int | int[])`
+- Quadrants: 0 Infrastructure, 1 Languages & Frameworks, 2 Services & LLMs, 3 Tools & Methodologies  
+- Rings: 0 Primary, 1 Consider, 2 Experiment, 3 Avoid
+
+Examples:
+```json
+{"tool":"get_tech_stack_guidance","arguments": {"quadrant": 1, "ring": [0,1]}}
 ```
 
 ### Editing Technology Entries

--- a/public/radar-mcp.py
+++ b/public/radar-mcp.py
@@ -1,0 +1,170 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["mcp>=1.0.0"]
+# ///
+
+"""
+Minimal MCP server exposing a single tool that returns Tech Radar entries.
+
+Usage (no prior installs required via uv script metadata):
+
+  uv run https://radar.sandbox.aetheron.com/radar-mcp.py
+
+To test the MCP server, use the MCP Inspector:
+
+  npx @modelcontextprotocol/inspector
+
+Then configure your MCP-capable client (e.g., Cursor) to launch the above command.
+
+Tool name: "get_tech_stack_guidance"
+Arguments (all optional):
+  - quadrant: int | list[int]  (0=Infrastructure, 1=Languages & Frameworks, 2=Services & LLMs, 3=Tools & Methodologies)
+  - ring:     int | list[int]  (0=Primary, 1=Consider, 2=Experiment, 3=Avoid)
+
+The server fetches entries from RADAR_ENTRIES_URL (env override) or the hosted default.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import ssl
+import time
+import urllib.request
+from typing import Any, Iterable, TypedDict
+
+from mcp.server.fastmcp import FastMCP
+
+
+DEFAULT_ENTRIES_URL = "https://radar.sandbox.aetheron.com/radar-entries.json"
+ENTRIES_URL_ENV = "RADAR_ENTRIES_URL"
+
+
+def _as_int_set(value: int | Iterable[int] | None) -> set[int] | None:
+  """Normalize an int or iterable of ints into a set of ints; None passes through."""
+  if value is None:
+    return None
+  if isinstance(value, int):
+    return {value}
+  try:
+    return {int(v) for v in value}
+  except TypeError:
+    # Not iterable
+    return {int(value)}
+
+
+def _fetch_entries(url: str, timeout: float = 10.0) -> list[dict[str, Any]]:
+  """Fetch and parse the radar entries JSON from the given URL."""
+  ctx = ssl.create_default_context()
+  req = urllib.request.Request(url, headers={"User-Agent": "aetheron-mcp-radar/1.0"})
+  with urllib.request.urlopen(req, timeout=timeout, context=ctx) as resp:
+    charset = resp.headers.get_content_charset() or "utf-8"
+    data = resp.read().decode(charset)
+  parsed = json.loads(data)
+  if not isinstance(parsed, list):
+    raise ValueError("radar-entries.json did not contain a JSON array")
+  return [e for e in parsed if isinstance(e, dict)]
+
+
+def _filter_entries(
+  entries: list[dict[str, Any]], quadrants: set[int] | None, rings: set[int] | None
+) -> list[dict[str, Any]]:
+  """Filter entries by quadrant/ring if provided; results sorted by label."""
+  def keep(e: dict[str, Any]) -> bool:
+    if quadrants is not None and int(e.get("quadrant", -1)) not in quadrants:
+      return False
+    if rings is not None and int(e.get("ring", -1)) not in rings:
+      return False
+    return True
+
+  filtered = [e for e in entries if keep(e)]
+  filtered.sort(key=lambda x: (int(x.get("ring", 99)), str(x.get("label", ""))))
+  return filtered
+
+
+mcp = FastMCP("Aetheron Tech Radar")
+
+
+class Link(TypedDict):
+  title: str
+  url: str
+
+
+class RadarEntry(TypedDict, total=False):
+  label: str
+  quadrant: int
+  ring: int
+  summary: str
+  decision: str
+  when_to_use: list[str]
+  consider_alternitive: list[str]
+  links: list[Link]
+  logo: str
+
+
+class Filters(TypedDict):
+  quadrant: list[int] | None
+  ring: list[int] | None
+
+
+class RadarResponse(TypedDict):
+  source_url: str
+  filters: Filters
+  count: int
+  duration_ms: int
+  entries: list[RadarEntry]
+
+
+# Load once at startup (simple strategy)
+_SOURCE_URL = os.environ.get(ENTRIES_URL_ENV, DEFAULT_ENTRIES_URL)
+_ENTRIES: list[RadarEntry] = _fetch_entries(_SOURCE_URL)  # type: ignore[assignment]
+
+
+@mcp.tool()
+def get_tech_stack_guidance(
+  quadrant: int | list[int] | None = None,
+  ring: int | list[int] | None = None,
+) -> RadarResponse:
+  """Get Aetheron's official technology decisions and recommendations from our Tech Radar.
+  
+  Use this tool when:
+  - Designing new features or products to choose the right tech stack
+  - Writing PRDs or technical specifications 
+  - Making architecture decisions or technology trade-offs
+  - Evaluating whether to adopt, consider, experiment with, or avoid specific technologies
+  - Understanding our standard practices and approved alternatives
+  
+  Returns our curated technology choices with decision rationale, use cases, and alternatives.
+  
+  Quadrants: 0=Infrastructure, 1=Languages & Frameworks, 2=Services & LLMs, 3=Tools & Methodologies
+  Rings: 0=Primary (default choice), 1=Consider (case-by-case), 2=Experiment (trial phase), 3=Avoid (use alternatives)
+  
+  Examples:
+  - get_tech_stack_guidance() - Get all technology decisions
+  - get_tech_stack_guidance(quadrant=1, ring=[0,1]) - Primary + Consider languages/frameworks
+  - get_tech_stack_guidance(ring=0) - All primary/default technologies across categories
+  """
+  started = time.time()
+
+  quadrants = _as_int_set(quadrant)
+  rings = _as_int_set(ring)
+  filtered = _filter_entries(_ENTRIES, quadrants, rings)
+  duration_ms = int((time.time() - started) * 1000)
+
+  return {
+    "source_url": _SOURCE_URL,
+    "filters": {
+      "quadrant": sorted(quadrants) if quadrants is not None else None,
+      "ring": sorted(rings) if rings is not None else None,
+    },
+    "count": len(filtered),
+    "duration_ms": duration_ms,
+    "entries": filtered,
+  }
+
+
+if __name__ == "__main__":
+  # Defaults to stdio transport; clients like Cursor can spawn this directly.
+  mcp.run()
+
+


### PR DESCRIPTION
- Introduced a new `radar-mcp.py` script that serves as a minimal MCP server exposing the `get_tech_stack_guidance` tool.
- Updated README.md to include installation instructions for the MCP server and detailed usage examples for the new tool.
- Added information on filtering technology entries by quadrant and ring, improving clarity on tech stack recommendations.